### PR TITLE
feat(GH-49): add SMTP environment variables to Lambda function

### DIFF
--- a/infrastructure/dev/lambda.tf
+++ b/infrastructure/dev/lambda.tf
@@ -32,6 +32,11 @@ resource "aws_lambda_function" "calendar" {
 
       ICAL_URL_PARAM      = "/calendar/dev/ical-feed-url"
       DYNAMODB_TABLE_NAME = aws_dynamodb_table.calendar_events.name
+
+      SMTP_FROM_EMAIL_PARAM  = "/calendar/dev/smtp-from-email"
+      SMTP_SENDER_NAME_PARAM = "/calendar/dev/smtp-sender-name"
+      SMTP_USERNAME_PARAM    = "/calendar/dev/smtp-username"
+      SMTP_PASSWORD_PARAM    = "/calendar/dev/smtp-password"
     }
   }
 }

--- a/infrastructure/prod/lambda.tf
+++ b/infrastructure/prod/lambda.tf
@@ -32,6 +32,11 @@ resource "aws_lambda_function" "calendar" {
 
       ICAL_URL_PARAM      = "/calendar/prod/ical-feed-url"
       DYNAMODB_TABLE_NAME = aws_dynamodb_table.calendar_events.name
+
+      SMTP_FROM_EMAIL_PARAM  = "/calendar/prod/smtp-from-email"
+      SMTP_SENDER_NAME_PARAM = "/calendar/prod/smtp-sender-name"
+      SMTP_USERNAME_PARAM    = "/calendar/prod/smtp-username"
+      SMTP_PASSWORD_PARAM    = "/calendar/prod/smtp-password"
     }
   }
 }


### PR DESCRIPTION
## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Description
Add SMTP SSM parameter references as environment variables to the Lambda function for both dev and prod environments:
- `SMTP_FROM_EMAIL_PARAM`
- `SMTP_SENDER_NAME_PARAM`
- `SMTP_USERNAME_PARAM`
- `SMTP_PASSWORD_PARAM`

These variables enable the Lambda function to retrieve SMTP credentials from SSM Parameter Store for email sending functionality.

## Related Issue
Closes #49